### PR TITLE
백준 온라인 저지(BOJ) 랭킹 기능입니다.

### DIFF
--- a/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
@@ -53,6 +53,7 @@ public class User {
 
     private String img;
 
+    private String bojId;
     // solvedCount - 사용자가 푼 문제 수
     @Column(length = 8)
     private long solvedCount;
@@ -71,7 +72,7 @@ public class User {
     private long maxStreak;
 
     @Builder
-    public User(String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg, String img, long solvedCount, long exp, long tier, long maxStreak) {
+    public User(String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg, String img, String bojId, long solvedCount, long exp, long tier, long maxStreak) {
         this.password = password;
         this.role = role;
         this.email = email;
@@ -84,6 +85,7 @@ public class User {
         this.commits = commits;
         this.githubMsg = githubMsg;
         this.img = img;
+        this.bojId = bojId;
         this.solvedCount = solvedCount;
         this.exp = exp;
         this.tier = tier;
@@ -124,4 +126,12 @@ public class User {
     public void updateImg(String img) {
         this.img = img;
     }
+
+    public void updateUserBojInfo(Long solvedCount, Long tier, Long exp, Long maxStreak) {
+        this.solvedCount = solvedCount;
+        this.tier = tier;
+        this.exp = exp;
+        this.maxStreak = maxStreak;
+    }
+
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
@@ -54,16 +54,20 @@ public class User {
     private String img;
 
     // solvedCount - 사용자가 푼 문제 수
+    @Column(length = 8)
     private long solvedCount;
 
     // exp - 사용자가 여태까지 획득한 경험치량
+    @Column(length = 64)
     private long exp;
 
     // tier - Bronze V를 1, Bronze IV를 2, ...,
     // Ruby I을 30, Master를 31로 표현하는 사용자 티어
+    @Column(length = 4)
     private long tier;
 
     // maxStreak - 최대 연속 문제 풀이일 수
+    @Column(length = 8)
     private long maxStreak;
 
     @Builder

--- a/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
@@ -53,9 +53,21 @@ public class User {
 
     private String img;
 
+    // solvedCount - 사용자가 푼 문제 수
+    private long solvedCount;
+
+    // exp - 사용자가 여태까지 획득한 경험치량
+    private long exp;
+
+    // tier - Bronze V를 1, Bronze IV를 2, ...,
+    // Ruby I을 30, Master를 31로 표현하는 사용자 티어
+    private long tier;
+
+    // maxStreak - 최대 연속 문제 풀이일 수
+    private long maxStreak;
+
     @Builder
-    public User(Long id, String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg) {
-        this.id = id;
+    public User(String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg, String img, long solvedCount, long exp, long tier, long maxStreak) {
         this.password = password;
         this.role = role;
         this.email = email;
@@ -67,6 +79,11 @@ public class User {
         this.githubId = githubId;
         this.commits = commits;
         this.githubMsg = githubMsg;
+        this.img = img;
+        this.solvedCount = solvedCount;
+        this.exp = exp;
+        this.tier = tier;
+        this.maxStreak = maxStreak;
     }
 
     // auth

--- a/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/domain/User.java
@@ -7,6 +7,8 @@ import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
+import java.util.HashMap;
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -71,8 +73,11 @@ public class User {
     @Column(length = 8)
     private long maxStreak;
 
+    private String bojAuthId;
+    private String randomCode;
+
     @Builder
-    public User(String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg, String img, String bojId, long solvedCount, long exp, long tier, long maxStreak) {
+    public User(String password, Role role, String email, int studentGrade, int studentClassNo, int studentNo, String name, String bsmToken, String githubId, int commits, String githubMsg, String img, String bojId, long solvedCount, long exp, long tier, long maxStreak, String bojAuthId, String randomCode) {
         this.password = password;
         this.role = role;
         this.email = email;
@@ -90,6 +95,8 @@ public class User {
         this.exp = exp;
         this.tier = tier;
         this.maxStreak = maxStreak;
+        this.bojAuthId = bojAuthId;
+        this.randomCode = randomCode;
     }
 
     // auth
@@ -121,6 +128,14 @@ public class User {
 
     public void updateGithubMsg(String msg) {
         this.githubMsg = msg;
+    }
+
+    public void updateBojAuthId(String bojAuthId) {
+        this.bojAuthId = bojAuthId;
+    }
+
+    public void updateRandomCode(String randomCode) {
+        this.randomCode = randomCode;
     }
 
     public void updateImg(String img) {

--- a/src/main/java/bssm/db/bssmgit/domain/user/repository/UserRepository.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/repository/UserRepository.java
@@ -21,4 +21,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("select u from User u order by u.commits DESC")
     Page<User> findAll(Pageable pageable);
+
+    @Query("select u from User u order by u.exp DESC")
+    Page<User> findBojAll(Pageable pageable);
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/service/AuthService.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/service/AuthService.java
@@ -120,12 +120,15 @@ public class AuthService {
 
         User user = userRepository.findByEmail(SecurityUtil.getLoginUserEmail())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_LOGIN));
-        user.updateGitId(userProfile.getGitId());
 
-        user.updateCommits(github.searchCommits().author(user.getGithubId())
-                .list().getTotalCount());
-        user.updateGithubMsg(github.getUser(user.getGithubId()).getBio());
-        user.updateImg(github.getUser(user.getGithubId()).getAvatarUrl());
+        if (user.getGithubId() == null) {
+            user.updateGitId(userProfile.getGitId());
+
+            user.updateCommits(github.searchCommits().author(user.getGithubId())
+                    .list().getTotalCount());
+            user.updateGithubMsg(github.getUser(user.getGithubId()).getBio());
+            user.updateImg(github.getUser(user.getGithubId()).getAvatarUrl());
+        }
 
         return new GitLoginResponseDto(user.getGithubId());
     }

--- a/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
@@ -1,7 +1,9 @@
 package bssm.db.bssmgit.domain.user.service;
 
 import bssm.db.bssmgit.domain.user.repository.UserRepository;
+import bssm.db.bssmgit.domain.user.web.dto.response.BojUserResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +18,9 @@ import java.net.ProtocolException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.StringTokenizer;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -111,4 +115,9 @@ public class BojService {
                 });
     }
 
+    public List<BojUserResponseDto> findAllUserBojDesc(Pageable pageable) {
+        return userRepository.findBojAll(pageable).stream()
+                .map(BojUserResponseDto::new)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
@@ -1,0 +1,114 @@
+package bssm.db.bssmgit.domain.user.service;
+
+import bssm.db.bssmgit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+@RequiredArgsConstructor
+@Service
+public class BojService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 4 * * * *") // 매일 새벽 4시
+    public void updateUserBojInfo() throws IOException {
+        final String bojId;
+
+        userRepository.findAll()
+                .stream().filter(u -> u.getGithubId() != null)
+                .forEach(u -> {
+                    URL url = null;
+                    try {
+                        url = new URL("https://solved.ac/api/v3/user/show" + "?handle=" + u.getBojId());
+                    } catch (MalformedURLException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    HttpURLConnection urlConnection = null;
+                    try {
+                        urlConnection = (HttpURLConnection) url.openConnection();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    try {
+                        urlConnection.setRequestMethod("GET");
+                    } catch (ProtocolException e) {
+                        throw new RuntimeException(e);
+                    }
+                    try {
+                        urlConnection.connect();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    BufferedInputStream bufferedInputStream = null;
+                    try {
+                        bufferedInputStream = new BufferedInputStream(urlConnection.getInputStream());
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    BufferedReader br = new BufferedReader(new InputStreamReader(bufferedInputStream, StandardCharsets.UTF_8));
+
+                    StringBuilder sb = new StringBuilder();
+                    String s;
+
+                    ArrayList<String> list = new ArrayList<>();
+                    while (true) {
+                        try {
+                            if ((s = br.readLine()) == null) break;
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                        sb.append(s);
+                    }
+
+                    StringTokenizer st = new StringTokenizer(sb.toString(), ",");
+                    int tokens = st.countTokens();
+
+                    for (int i = 0; i < tokens; i++) {
+                        String word = st.nextToken();
+                        if (word.contains("solvedCount") ||
+                                word.contains("exp") ||
+                                word.contains("tier") ||
+                                word.contains("maxStreak")) list.add(word);
+                    }
+
+                    ArrayList<String> properties = new ArrayList<>();
+                    for (String property : list) {
+                        StringTokenizer stt = new StringTokenizer(property, ":");
+                        stt.nextToken();
+                        properties.add(stt.nextToken());
+                    }
+
+                    ArrayList<String> result = new ArrayList<>();
+                    for (String bojInfo : properties) {
+                        StringTokenizer st2 = new StringTokenizer(bojInfo, "\"");
+                        bojInfo = st2.nextToken();
+                        result.add(bojInfo);
+                    }
+
+                    long solvedCount = Long.parseLong(result.get(0));
+                    long tier = Long.parseLong(result.get(1));
+                    long exp = Long.parseLong(result.get(2));
+                    long maxStreak = Long.parseLong(result.get(3));
+
+                    u.updateUserBojInfo(solvedCount, tier, exp, maxStreak);
+                });
+    }
+
+}

--- a/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/service/BojService.java
@@ -49,11 +49,13 @@ public class BojService {
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
+
                     try {
                         urlConnection.setRequestMethod("GET");
                     } catch (ProtocolException e) {
                         throw new RuntimeException(e);
                     }
+
                     try {
                         urlConnection.connect();
                     } catch (IOException e) {
@@ -61,11 +63,13 @@ public class BojService {
                     }
 
                     BufferedInputStream bufferedInputStream = null;
+
                     try {
                         bufferedInputStream = new BufferedInputStream(urlConnection.getInputStream());
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
+
                     BufferedReader br = new BufferedReader(new InputStreamReader(bufferedInputStream, StandardCharsets.UTF_8));
 
                     StringBuilder sb = new StringBuilder();

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/api/AuthApiController.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/api/AuthApiController.java
@@ -23,7 +23,7 @@ public class AuthApiController {
         return authService.bsmLogin(request.getHeader("authCode"));
     }
 
-    @GetMapping("/login/oauth/github")
+    @PostMapping("/login/oauth/github")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<GitLoginResponseDto> login(@RequestParam String code) throws IOException {
         GitLoginResponseDto loginResponse = authService.gitLogin(code);

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/api/AuthApiController.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/api/AuthApiController.java
@@ -1,7 +1,10 @@
 package bssm.db.bssmgit.domain.user.web.api;
 
 import bssm.db.bssmgit.domain.user.service.AuthService;
+import bssm.db.bssmgit.domain.user.service.BojService;
+import bssm.db.bssmgit.domain.user.web.dto.response.BojAuthenticationResultResDto;
 import bssm.db.bssmgit.domain.user.web.dto.response.GitLoginResponseDto;
+import bssm.db.bssmgit.domain.user.web.dto.response.RandomCodeResponseDto;
 import bssm.db.bssmgit.domain.user.web.dto.response.TokenResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +19,7 @@ import java.io.*;
 public class AuthApiController {
 
     private final AuthService authService;
+    private final BojService bojService;
 
     @PostMapping("/auth/oauth/bsm")
     @ResponseStatus(HttpStatus.OK)
@@ -28,6 +32,18 @@ public class AuthApiController {
     public ResponseEntity<GitLoginResponseDto> login(@RequestParam String code) throws IOException {
         GitLoginResponseDto loginResponse = authService.gitLogin(code);
         return ResponseEntity.ok().body(loginResponse);
+    }
+
+    @GetMapping("/boj/random")
+    @ResponseStatus(HttpStatus.OK)
+    public RandomCodeResponseDto getRandomCode(@RequestParam String bojId) {
+        return bojService.getRandomCode(bojId);
+    }
+
+    @PostMapping("/auth/boj")
+    @ResponseStatus(HttpStatus.OK)
+    public BojAuthenticationResultResDto bojAuthentication() throws IOException {
+        return bojService.matchedCode();
     }
 
     @PutMapping("/refresh")

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
@@ -2,6 +2,7 @@ package bssm.db.bssmgit.domain.user.web.api;
 
 import bssm.db.bssmgit.domain.user.service.BojService;
 import bssm.db.bssmgit.domain.user.service.UserService;
+import bssm.db.bssmgit.domain.user.web.dto.response.BojUserResponseDto;
 import bssm.db.bssmgit.domain.user.web.dto.response.UserResponseDto;
 import bssm.db.bssmgit.global.generic.Result;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +23,15 @@ public class UserApiController {
     private final UserService userService;
     private final BojService bojService;
 
-    @GetMapping
+    @GetMapping("/git")
     @ResponseStatus(HttpStatus.OK)
-    public Result findAllUserDesc(@PageableDefault(size = 10, sort = {"id"}, direction = Sort.Direction.DESC)
-                                      Pageable pageable) {
+    public Result findAllUserGit(
+            @PageableDefault(size = 10)
+            Pageable pageable) {
+
         List<UserResponseDto> userList = userService.findAll(pageable);
         return new Result(userList.size(), userList);
+
     }
 
     @PostMapping
@@ -35,4 +39,13 @@ public class UserApiController {
         bojService.updateUserBojInfo();
     }
 
+    @GetMapping("/boj")
+    @ResponseStatus(HttpStatus.OK)
+    public Result findAllUserBoj(
+            @PageableDefault(size = 10)
+            Pageable pageable) {
+
+        List<BojUserResponseDto> allUserBojDesc = bojService.findAllUserBojDesc(pageable);
+        return new Result(allUserBojDesc.size(), allUserBojDesc);
+    }
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
@@ -1,5 +1,6 @@
 package bssm.db.bssmgit.domain.user.web.api;
 
+import bssm.db.bssmgit.domain.user.service.BojService;
 import bssm.db.bssmgit.domain.user.service.UserService;
 import bssm.db.bssmgit.domain.user.web.dto.response.UserResponseDto;
 import bssm.db.bssmgit.global.generic.Result;
@@ -10,6 +11,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -18,6 +20,7 @@ import java.util.List;
 public class UserApiController {
 
     private final UserService userService;
+    private final BojService bojService;
 
     @GetMapping
     @ResponseStatus(HttpStatus.OK)
@@ -26,4 +29,10 @@ public class UserApiController {
         List<UserResponseDto> userList = userService.findAll(pageable);
         return new Result(userList.size(), userList);
     }
+
+    @PostMapping
+    public void bojTest() throws IOException {
+        bojService.updateUserBojInfo();
+    }
+
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/api/UserApiController.java
@@ -7,7 +7,6 @@ import bssm.db.bssmgit.domain.user.web.dto.response.UserResponseDto;
 import bssm.db.bssmgit.global.generic.Result;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -48,4 +47,5 @@ public class UserApiController {
         List<BojUserResponseDto> allUserBojDesc = bojService.findAllUserBojDesc(pageable);
         return new Result(allUserBojDesc.size(), allUserBojDesc);
     }
+
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojAuthenticationResultResDto.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojAuthenticationResultResDto.java
@@ -1,0 +1,10 @@
+package bssm.db.bssmgit.domain.user.web.dto.response;
+
+import lombok.Data;
+
+@Data
+public class BojAuthenticationResultResDto {
+
+    private final boolean result;
+
+}

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
@@ -3,8 +3,6 @@ package bssm.db.bssmgit.domain.user.web.dto.response;
 import bssm.db.bssmgit.domain.user.domain.User;
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 public class BojUserResponseDto {
 
@@ -21,7 +19,6 @@ public class BojUserResponseDto {
         this.exp = user.getExp();
         this.tier = user.getTier();
         this.maxStreak = user.getMaxStreak();
-        UserResponseDto userResponseDto = new UserResponseDto(user);
-        this.user = userResponseDto;
+        this.user = new UserResponseDto(user);
     }
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
@@ -1,0 +1,24 @@
+package bssm.db.bssmgit.domain.user.web.dto.response;
+
+import bssm.db.bssmgit.domain.user.domain.User;
+import lombok.Data;
+
+@Data
+public class BojUserResponseDto {
+
+    private final Long userId;
+    private final String bojId;
+    private final long solvedCount;
+    private final long exp;
+    private final long tier;
+    private final long maxStreak;
+
+    public BojUserResponseDto(User user) {
+        this.userId = user.getId();
+        this.bojId = user.getBojId();
+        this.solvedCount = user.getSolvedCount();
+        this.exp = user.getExp();
+        this.tier = user.getTier();
+        this.maxStreak = user.getMaxStreak();
+    }
+}

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/BojUserResponseDto.java
@@ -3,22 +3,25 @@ package bssm.db.bssmgit.domain.user.web.dto.response;
 import bssm.db.bssmgit.domain.user.domain.User;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 public class BojUserResponseDto {
 
-    private final Long userId;
     private final String bojId;
     private final long solvedCount;
     private final long exp;
     private final long tier;
     private final long maxStreak;
+    private final UserResponseDto user;
 
     public BojUserResponseDto(User user) {
-        this.userId = user.getId();
         this.bojId = user.getBojId();
         this.solvedCount = user.getSolvedCount();
         this.exp = user.getExp();
         this.tier = user.getTier();
         this.maxStreak = user.getMaxStreak();
+        UserResponseDto userResponseDto = new UserResponseDto(user);
+        this.user = userResponseDto;
     }
 }

--- a/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/RandomCodeResponseDto.java
+++ b/src/main/java/bssm/db/bssmgit/domain/user/web/dto/response/RandomCodeResponseDto.java
@@ -1,0 +1,13 @@
+package bssm.db.bssmgit.domain.user.web.dto.response;
+
+import lombok.Data;
+
+@Data
+public class RandomCodeResponseDto {
+
+    private final String code;
+
+    public RandomCodeResponseDto(String code) {
+        this.code = code;
+    }
+}


### PR DESCRIPTION
## Feature
* 백준 테이블을 따로 만드는 대신 사용하던 User 테이블에 백준과 관련된 정보들을 컬럼으로 추가하였습니다.
* Solved.ac에서 매번 요청하면 속도가 느리니 깃허브 커밋 업데이트 방식과 동일하게 유저들의 사용량이 적은 시간대에 스케쥴러를 배치했습니다.
* 유저 컬럼에 백준 아이디가 null이면 업데이트가 이루어지지 않습니다.
* 백준 정보들에 관련된 컬럼들을 한번에 업데이트 시켜주도록 생성자를 묶어놓았습니다. (커밋도 이렇게 관리해야할듯)
* 반환값에 백준 정보뿐만 아니라 유저 관련 정보도 같이 반환합니다. (플러터 장인의 요청)
* 반환되는 json 형태는 다음과 같습니다.

## Return
```json
{
    "count": 1,
    "data": [
        {
            "bojId": "qorwnsduftlagl",
            "solvedCount": 166,
            "exp": 738698,
            "tier": 11,
            "maxStreak": 27,
            "user": {
                "email": "202110414@bssm.hs.kr",
                "studentGrade": 2,
                "studentClassNo": 2,
                "studentNo": 14,
                "name": "최원용",
                "githubId": "wonyongChoi05",
                "commits": 799,
                "bio": "625625n",
                "img": "https://avatars.githubusercontent.com/u/94087228?v=4"
            }
        }
    ]
}
```

* `solvedCount` - 사용자가 푼 문제 수
* `exp` - 사용자가 여태까지 획득한 경험치량
* `tier` - Bronze V를 1, Bronze IV를 2, ..., Ruby I을 30, Master를 31로 표현하는 사용자 티어
* `maxStreak` - 최대 연속 문제 풀이 일 수

## 문제점
유저의 백준 아이디를 어떻게 받을것인가가 문제입니다.
Solved.ac는 인증 서비스를 제공해주지 않습니다. 

1. 사용자의 양심에 맞기고 직접 입력하게 하는 방법
2. 더 좋은 방법이 있다면 알려주세요..!

***

## 개선의 여지
지금 당장은 부산소마고에만 국한되어있지만, sovled.ac에서 올가니제이션에 대한 api 또한 제공해주니, 소마고 4개학교 학생들을 대상으로 서비스를 해도 괜찮을 것 같습니다.